### PR TITLE
fix: relax version constrains

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,25 +1,25 @@
 terraform {
-  required_version = "~> 1.9"
+  required_version = ">= 1.9"
 
   required_providers {
     azapi = {
       source  = "azure/azapi"
-      version = "~> 1.14"
+      version = ">= 1.14"
     }
 
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.111"
+      version = ">= 3.111"
     }
 
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.0"
+      version = ">= 3.0"
     }
 
     tls = {
       source  = "hashicorp/tls"
-      version = "~> 4.0"
+      version = ">= 4.0"
     }
   }
 }


### PR DESCRIPTION
I'm pro for relax version constraints.

Public modules like https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/versions.tf do this as well. End-users could always use stricter version constraints but modules should always give a bit more flexibility. 