### PR TITLE
Use min version 3.1.0 on "random" provider

### DIFF
--- a/.github/workflows/module-ci.yaml
+++ b/.github/workflows/module-ci.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   module-ci:
-    uses: cloudeteer/terraform-governance/.github/workflows/module-ci.yaml@main
+    uses: cloudeteer/terraform-governance/.github/workflows/module-ci.yaml@42-use-a-specific-terraform-version-during-githubu-actions
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/module-ci.yaml
+++ b/.github/workflows/module-ci.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   module-ci:
-    uses: cloudeteer/terraform-governance/.github/workflows/module-ci.yaml@42-use-a-specific-terraform-version-during-githubu-actions
+    uses: cloudeteer/terraform-governance/.github/workflows/module-ci.yaml@main
     permissions:
       contents: write
       id-token: write

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The following providers are used by this module:
 
 - <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) (>= 4.1)
 
-- <a name="provider_random"></a> [random](#provider\_random) (>= 3.0)
+- <a name="provider_random"></a> [random](#provider\_random) (>= 3.1)
 
 - <a name="provider_tls"></a> [tls](#provider\_tls) (>= 4.0)
 

--- a/tests/remote/terraform.tf
+++ b/tests/remote/terraform.tf
@@ -14,7 +14,7 @@ terraform {
 
     random = {
       source  = "hashicorp/random"
-      version = "3.0"
+      version = "3.1.0"
     }
 
     tls = {

--- a/tests/remote/terraform.tf
+++ b/tests/remote/terraform.tf
@@ -1,25 +1,25 @@
 terraform {
-  required_version = "~> 1.9"
+  required_version = "1.9.0"
 
   required_providers {
     azapi = {
       source  = "azure/azapi"
-      version = "~> 1.14"
+      version = "1.14.0"
     }
 
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.1"
+      version = "4.1.0"
     }
 
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.0"
+      version = "3.0"
     }
 
     tls = {
       source  = "hashicorp/tls"
-      version = "~> 4.0"
+      version = "4.0.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -14,7 +14,7 @@ terraform {
 
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.0"
+      version = ">= 3.1"
     }
 
     tls = {


### PR DESCRIPTION
- **Run remote test with fixed minimum provider version**
- **Use random provider version `3.1.0`**
