### PR TITLE
Block AzAPI provider `>= 2.0.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ module "example" {
 
 The following providers are used by this module:
 
-- <a name="provider_azapi"></a> [azapi](#provider\_azapi) (>= 1.14)
+- <a name="provider_azapi"></a> [azapi](#provider\_azapi) (~> 1.14)
 
 - <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) (>= 4.1)
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "azure/azapi"
-      version = ">= 1.14"
+      version = "~> 1.14"
     }
 
     azurerm = {


### PR DESCRIPTION
azure/azapi introduced a breaking change in 2.0 where JSON output is replaced by native HCL output.

Since the output type is changes from string to complex, jsondecode does not longer work

```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Invalid function argument
│ 
│   on .terraform/modules/vm-relc-a-p-1/d-image.tf line 52, in locals:
│   52:     jsondecode(one(data.azapi_resource_list.virtual_machine_images[*].output)) :
│     ├────────────────
│     │ while calling jsondecode(str)
│     │ data.azapi_resource_list.virtual_machine_images is tuple with 1 element
│ 
│ Invalid value for "str" parameter: string required.
╵

Error: Process completed with exit code 1.
```