### PR TITLE
Do not install VM extensions when `var.allow_extension_operations` is `false`

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ Possible values:
 - `AzurePolicy`
 - `AntiMalware`
 
-Note: The extensions listed here will only be applied if `allow_extension_operations` is set to `true`. If `allow_extension_operations` is set to `false`, this list will be ignored and no extensions will be created.
+**NOTE**: The extensions listed here will only be applied if `allow_extension_operations` is set to `true` (default). If `allow_extension_operations` is set to `false`, this list will be ignored and no extensions will be created.
 
 Type: `list(string)`
 

--- a/README.md
+++ b/README.md
@@ -445,6 +445,8 @@ Possible values:
 - `AzurePolicy`
 - `AntiMalware`
 
+Note: The extensions listed here will only be applied if `allow_extension_operations` is set to `true`. If `allow_extension_operations` is set to `false`, this list will be ignored and no extensions will be created.
+
 Type: `list(string)`
 
 Default:

--- a/r-extensions.tf
+++ b/r-extensions.tf
@@ -48,7 +48,7 @@ resource "azurerm_virtual_machine_extension" "this" {
       (local.is_windows ? local.windows_extenstion : []),
       (local.is_linux ? local.linux_extensions : [])
     ) :
-    element.name => element if contains(var.extensions, element.name)
+    element.name => element if contains(var.extensions, element.name) && var.allow_extension_operations
   }
 
   virtual_machine_id = local.virtual_machine.id

--- a/tests/local/input_vm_extension.tftest.hcl
+++ b/tests/local/input_vm_extension.tftest.hcl
@@ -1,0 +1,31 @@
+mock_provider "azapi" { source = "tests/local/mocks" }
+mock_provider "azurerm" { source = "tests/local/mocks" }
+mock_provider "random" { source = "tests/local/mocks" }
+mock_provider "tls" { source = "tests/local/mocks" }
+
+run "no_extension_should_be_created" {
+  command = plan
+
+  variables {
+    allow_extension_operations = false
+    extensions                 = []
+  }
+
+  assert {
+    condition     = length(azurerm_virtual_machine_extension.this) == 0
+    error_message = "It is not possible to install extension with 'allow_extension_operations = false'. The azurerm_virtual_machine_extension.this length is ${length(azurerm_virtual_machine_extension.this)}."
+  }
+}
+
+run "no_extension_should_be_created_2" {
+  command = plan
+
+  variables {
+    allow_extension_operations = false
+  }
+
+  assert {
+    condition     = length(azurerm_virtual_machine_extension.this) == 0
+    error_message = "It is not possible to install extension with 'allow_extension_operations = false'. The azurerm_virtual_machine_extension.this length is ${length(azurerm_virtual_machine_extension.this)}."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -258,7 +258,7 @@ variable "extensions" {
     - `AzurePolicy`
     - `AntiMalware`
 
-    Note: The extensions listed here will only be applied if `allow_extension_operations` is set to `true`. If `allow_extension_operations` is set to `false`, this list will be ignored and no extensions will be created.
+    **NOTE**: The extensions listed here will only be applied if `allow_extension_operations` is set to `true` (default). If `allow_extension_operations` is set to `false`, this list will be ignored and no extensions will be created.
   EOT
 
   type = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -257,6 +257,8 @@ variable "extensions" {
     - `AzureMonitorAgent`
     - `AzurePolicy`
     - `AntiMalware`
+
+    Note: The extensions listed here will only be applied if `allow_extension_operations` is set to `true`. If `allow_extension_operations` is set to `false`, this list will be ignored and no extensions will be created.
   EOT
 
   type = list(string)


### PR DESCRIPTION
Updated the for_each block to dynamically control extension creation.