### PR TITLE
Add GitHub release notes configuration

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,17 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-release
+  categories:
+    - title: Breaking Changes 💥
+      labels:
+        - breaking-change
+    - title: New Features ✨
+      labels:
+        - feature
+    - title: Bug Fixes 🐛
+      labels:
+        - fix
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This pull requests add the GitHub release notes configuration for autogenerated release notes

Docs: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

## PR Checklist
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added documentation written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have checked for a proper tag for this PR: `breaking-change`, `feature`, `fix`, `other`, `ignore-release`
- [x] I have used a **meaningful** PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
