### PR TITLE
Fix identity type fallback when `entra_id_login` is not enabled

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -4,13 +4,14 @@ locals {
     "RHEL_BYOS", "RHEL_BASE", "RHEL_EUS", "RHEL_SAPAPPS", "RHEL_SAPHA", "RHEL_BASESAPAPPS", "RHEL_BASESAPHA",
     "SLES_BYOS", "SLES_SAP", "SLES_HPC"
   ]
+
   identity_type = (
     var.entra_id_login.enabled ? (
       try(var.identity.type, "") == "UserAssigned" ?
       replace(var.identity.type, "UserAssigned", "SystemAssigned, UserAssigned") :
       "SystemAssigned"
     ) :
-  null)
+  try(var.identity.type, null))
 }
 
 variable "additional_capabilities" {


### PR DESCRIPTION
This PR fixes the logic for determining the identity type.

- If `var.entra_id_login` is **disabled**, the fallback value for `local.identity_type` will be `var.identity.type`.
- If `var.identity` or `var.identity.type` is **null**, then `local.identity_type` will also be **null**.
- If `var.identity.type` is **explicitly set** (e.g., as shown in example #64), it will be used as the value for `local.identity_type`.