### PR TITLE
Support data disk `create_option = Copy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ Optional parameters:
 Parameter | Description
 -- | --
 `caching` | Specifies the caching requirements for this Data Disk. Possible values include `None`, `ReadOnly` and `ReadWrite`.
-`create_option` | The method to use when creating the managed disk. Possible values include: `Empty` - Create an empty managed disk.
+`create_option` | The method to use when creating the managed disk. Possible values include: `Empty` - Create an empty managed disk. `Copy` - Copy an existing managed disk or snapshot (specified with `source_resource_id`).
 `name` | Specifies the name of the Managed Disk. If omitted a name will be generated based on `name`.
 `storage_account_type` | The type of storage to use for the managed disk. Possible values are `Standard_LRS`, `StandardSSD_ZRS`, `Premium_LRS`, `PremiumV2_LRS`, `Premium_ZRS`, `StandardSSD_LRS` or `UltraSSD_LRS`.
 

--- a/README.md
+++ b/README.md
@@ -411,8 +411,8 @@ list(object({
     disk_size_gb         = number
     lun                  = number
     name                 = optional(string)
-    storage_account_type = optional(string, "Premium_LRS")
     source_resource_id   = optional(string)
+    storage_account_type = optional(string, "Premium_LRS")
   }))
 ```
 

--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ list(object({
     lun                  = number
     name                 = optional(string)
     storage_account_type = optional(string, "Premium_LRS")
+    source_resource_id   = optional(string)
   }))
 ```
 

--- a/r-disk.tf
+++ b/r-disk.tf
@@ -20,10 +20,10 @@ resource "azurerm_managed_disk" "this" {
   resource_group_name = var.resource_group_name
   tags                = var.tags
 
-  storage_account_type = each.value.storage_account_type
   create_option        = each.value.create_option
   disk_size_gb         = each.value.disk_size_gb
   source_resource_id   = each.value.source_resource_id
+  storage_account_type = each.value.storage_account_type
   zone                 = var.zone
 }
 

--- a/r-disk.tf
+++ b/r-disk.tf
@@ -23,6 +23,7 @@ resource "azurerm_managed_disk" "this" {
   storage_account_type = each.value.storage_account_type
   create_option        = each.value.create_option
   disk_size_gb         = each.value.disk_size_gb
+  source_resource_id   = each.value.source_resource_id
   zone                 = var.zone
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -230,6 +230,7 @@ variable "data_disks" {
     lun                  = number
     name                 = optional(string)
     storage_account_type = optional(string, "Premium_LRS")
+    source_resource_id   = optional(string)
   }))
 
   default = []

--- a/variables.tf
+++ b/variables.tf
@@ -218,7 +218,7 @@ variable "data_disks" {
     Parameter | Description
     -- | --
     `caching` | Specifies the caching requirements for this Data Disk. Possible values include `None`, `ReadOnly` and `ReadWrite`.
-    `create_option` | The method to use when creating the managed disk. Possible values include: `Empty` - Create an empty managed disk.
+    `create_option` | The method to use when creating the managed disk. Possible values include: `Empty` - Create an empty managed disk. `Copy` - Copy an existing managed disk or snapshot (specified with `source_resource_id`).
     `name` | Specifies the name of the Managed Disk. If omitted a name will be generated based on `name`.
     `storage_account_type` | The type of storage to use for the managed disk. Possible values are `Standard_LRS`, `StandardSSD_ZRS`, `Premium_LRS`, `PremiumV2_LRS`, `Premium_ZRS`, `StandardSSD_LRS` or `UltraSSD_LRS`.
   EOT

--- a/variables.tf
+++ b/variables.tf
@@ -229,8 +229,8 @@ variable "data_disks" {
     disk_size_gb         = number
     lun                  = number
     name                 = optional(string)
-    storage_account_type = optional(string, "Premium_LRS")
     source_resource_id   = optional(string)
+    storage_account_type = optional(string, "Premium_LRS")
   }))
 
   default = []


### PR DESCRIPTION
This pull request adds support for setting `create_option = "Copy"` in the [`azurerm_managed_disk`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/managed_disk) resource by introducing the [`source_resource_id`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/managed_disk#source_resource_id-1) argument. This enables users to create managed data disks by copying from an existing disk or snapshot.