### PR TITLE
Implement AD Domain Join functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ The following resources are used by this module:
 - [azurerm_role_assignment.entra_id_login](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
 - [azurerm_user_assigned_identity.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) (resource)
 - [azurerm_virtual_machine_data_disk_attachment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_data_disk_attachment) (resource)
+- [azurerm_virtual_machine_extension.domain_join](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_extension) (resource)
 - [azurerm_virtual_machine_extension.entra_id_login](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_extension) (resource)
 - [azurerm_virtual_machine_extension.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_extension) (resource)
 - [azurerm_windows_virtual_machine.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_virtual_machine) (resource)
@@ -417,6 +418,60 @@ list(object({
 ```
 
 Default: `[]`
+
+### <a name="input_domain_join"></a> [domain\_join](#input\_domain\_join)
+
+Description: Enable domain join for the virtual machine. This feature is not supported on Linux Virtual Machines.
+
+Required parameters:
+
+Parameter | Description
+-- | --
+`enabled` | Whether to enable (`true`) or disable (`false`) domain join.
+`domain_name` | The name of the domain to join.
+`ou_path` | The Organizational Unit (OU) path in which to place the computer account.
+`join_user` | The username of the user who has permission to join the domain.
+
+Optional parameters:
+
+Parameter | Description
+-- | --
+`options` | Additional options for domain join. Default is `"3"`.
+`restart` | Whether to restart the VM after joining the domain. Default is `true`.
+
+Type:
+
+```hcl
+object({
+    enabled = bool
+
+    domain_name = string
+    join_user   = string
+    ou_path     = string
+
+    options = optional(string, "3")
+    restart = optional(bool, true)
+  })
+```
+
+Default:
+
+```json
+{
+  "domain_name": null,
+  "enabled": false,
+  "join_user": null,
+  "ou_path": null
+}
+```
+
+### <a name="input_domain_join_password"></a> [domain\_join\_password](#input\_domain\_join\_password)
+
+Description: Password for the domain join user (`domain_join.join_user`).
+
+Type: `string`
+
+Default: `null`
 
 ### <a name="input_enable_automatic_updates"></a> [enable\_automatic\_updates](#input\_enable\_automatic\_updates)
 

--- a/r-extensions.tf
+++ b/r-extensions.tf
@@ -81,3 +81,32 @@ resource "azurerm_virtual_machine_extension" "entra_id_login" {
     ignore_changes = [tags]
   }
 }
+
+resource "azurerm_virtual_machine_extension" "domain_join" {
+  count = var.domain_join.enabled ? 1 : 0
+
+  name                       = "DomainJoin"
+  publisher                  = "Microsoft.Compute"
+  type                       = "JsonADDomainExtension"
+  type_handler_version       = "1.0"
+  auto_upgrade_minor_version = true
+  automatic_upgrade_enabled  = false
+
+  virtual_machine_id = local.virtual_machine.id
+
+  settings = jsonencode({
+    Name    = var.domain_join.domain_name,
+    OUPath  = var.domain_join.ou_path,
+    User    = var.domain_join.join_user,
+    Restart = var.domain_join.restart,
+    Options = var.domain_join.options
+  })
+
+  protected_settings = jsonencode({
+    Password = var.domain_join_password
+  })
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -236,6 +236,54 @@ variable "data_disks" {
   default = []
 }
 
+variable "domain_join" {
+  description = <<-EOT
+    Enable domain join for the virtual machine. This feature is not supported on Linux Virtual Machines.
+
+    Required parameters:
+
+    Parameter | Description
+    -- | --
+    `enabled` | Whether to enable (`true`) or disable (`false`) domain join.
+    `domain_name` | The name of the domain to join.
+    `ou_path` | The Organizational Unit (OU) path in which to place the computer account.
+    `join_user` | The username of the user who has permission to join the domain.
+
+    Optional parameters:
+
+    Parameter | Description
+    -- | --
+    `options` | Additional options for domain join. Default is `"3"`.
+    `restart` | Whether to restart the VM after joining the domain. Default is `true`.
+  EOT
+
+  type = object({
+    enabled = bool
+
+    domain_name = string
+    join_user   = string
+    ou_path     = string
+
+    options = optional(string, "3")
+    restart = optional(bool, true)
+  })
+
+  default = {
+    enabled = false
+
+    domain_name = null
+    join_user   = null
+    ou_path     = null
+  }
+}
+
+variable "domain_join_password" {
+  type        = string
+  description = "Password for the domain join user (`domain_join.join_user`)."
+  sensitive   = true
+  default     = null
+}
+
 variable "enable_automatic_updates" {
   description = "Specifies whether Automatic Updates are enabled for Windows Virtual Machines. This feature is not supported on Linux Virtual Machines."
 


### PR DESCRIPTION
This PR adds Active Directory (AD) domain join functionality by introducing a VM extension and supporting input variables.

### Changes

- Added a VM extension to enable AD domain join.
- Introduced new input variables to configure the domain join process.

