### PR TITLE
Add ImageDefault to patch_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,13 +681,14 @@ Default: `"AutomaticByPlatform"`
 
 ### <a name="input_patch_mode"></a> [patch\_mode](#input\_patch\_mode)
 
-Description: Specifies the mode of in-guest patching to this Windows Virtual Machine. For more information on patch modes please see the [product documentation](https://docs.microsoft.com/azure/virtual-machines/automatic-vm-guest-patching#patch-orchestration-modes).
+Description: Specifies the mode of in-guest patching to this Virtual Machine. Defaults to AutomaticByPlatform. For more information on patch modes please see the [product documentation](https://docs.microsoft.com/azure/virtual-machines/automatic-vm-guest-patching#patch-orchestration-modes).
 
 **NOTE**: If `patch_mode` is set to `AutomaticByPlatform` then `provision_vm_agent` must also be set to true. If the Virtual Machine is using a hotpatching enabled image the `patch_mode` must always be set to `AutomaticByPlatform`.
 
 Possible values:
 - `AutomaticByOS`
 - `AutomaticByPlatform`
+- `ImageDefault`
 - `Manual`
 
 Type: `string`

--- a/variables.tf
+++ b/variables.tf
@@ -556,13 +556,14 @@ variable "patch_assessment_mode" {
 
 variable "patch_mode" {
   description = <<-EOT
-    Specifies the mode of in-guest patching to this Windows Virtual Machine. For more information on patch modes please see the [product documentation](https://docs.microsoft.com/azure/virtual-machines/automatic-vm-guest-patching#patch-orchestration-modes).
+    Specifies the mode of in-guest patching to this Virtual Machine. Defaults to AutomaticByPlatform. For more information on patch modes please see the [product documentation](https://docs.microsoft.com/azure/virtual-machines/automatic-vm-guest-patching#patch-orchestration-modes).
 
     **NOTE**: If `patch_mode` is set to `AutomaticByPlatform` then `provision_vm_agent` must also be set to true. If the Virtual Machine is using a hotpatching enabled image the `patch_mode` must always be set to `AutomaticByPlatform`.
 
     Possible values:
     - `AutomaticByOS`
     - `AutomaticByPlatform`
+    - `ImageDefault`
     - `Manual`
   EOT
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This update adds the `ImageDefault` option to the `patch_mode`, which was missing before.

## PR Checklist
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added documentation written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have checked for a proper tag for this PR: `breaking-change`, `feature`, `fix`, `other`, `ignore-release`
- [x] I have used a **meaningful** PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

none.