### PR TITLE
Fix incorrect `role_definition_id` usage in `azurerm_role_assignment`

### DIFF
--- a/r-identity.tf
+++ b/r-identity.tf
@@ -20,5 +20,5 @@ resource "azurerm_role_assignment" "entra_id_login" {
   principal_id = each.value
   scope = (local.is_linux ? azurerm_linux_virtual_machine.this[0].id :
   azurerm_windows_virtual_machine.this[0].id)
-  role_definition_id = "Virtual Machine Administrator Login"
+  role_definition_name = "Virtual Machine Administrator Login"
 }

--- a/r-identity.tf
+++ b/r-identity.tf
@@ -17,8 +17,7 @@ resource "azurerm_user_assigned_identity" "this" {
 resource "azurerm_role_assignment" "entra_id_login" {
   for_each = var.entra_id_login.enabled ? toset(var.entra_id_login.principal_ids) : []
 
-  principal_id = each.value
-  scope = (local.is_linux ? azurerm_linux_virtual_machine.this[0].id :
-  azurerm_windows_virtual_machine.this[0].id)
+  principal_id         = each.value
   role_definition_name = "Virtual Machine Administrator Login"
+  scope                = local.virtual_machine.id
 }


### PR DESCRIPTION
This PR fixes an issue where `azurerm_role_assignment` was incorrectly using the `role_definition_id` argument with a role **name** as its value. This caused the following error during `terraform apply`:

```
Error: unexpected status 400 (Bad Request): BadRequestFormat: The request was incorrectly formatted.
```

### Changes Made

- Replaced incorrect usage of `role_definition_id = "<role name>"`  
- Used `role_definition_name = "<role name>"` instead, which is the correct argument when providing a role name

### Notes

- This change ensures proper formatting and avoids 400 errors from the Azure API.
- No role definition GUIDs are required when using `role_definition_name`, simplifying the configuration.

### Tested

- Verified successful Terraform plan and apply after the change.
