### PR TITLE
Enhance Entra ID login configuration and role assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The following resources are used by this module:
 - [azurerm_managed_disk.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/managed_disk) (resource)
 - [azurerm_network_interface.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface) (resource)
 - [azurerm_public_ip.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) (resource)
-- [azurerm_role_assignment.entra_id_login](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
+- [azurerm_role_assignment.entra_id_login_admin](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
 - [azurerm_role_assignment.entra_id_login_user](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
 - [azurerm_user_assigned_identity.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) (resource)
 - [azurerm_virtual_machine_data_disk_attachment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_data_disk_attachment) (resource)

--- a/README.md
+++ b/README.md
@@ -501,8 +501,11 @@ Default: `true`
 
 ### <a name="input_entra_id_login"></a> [entra\_id\_login](#input\_entra\_id\_login)
 
-Description:   Configures Entra ID-based login for virtual machines. Set `enabled` to `true` to activate this feature and define the list of `principal_ids` permitted to log in.
+Description: Configures Entra ID-based login for virtual machines. Set `enabled` to `true` to activate this feature and specify the list of `principal_ids` permitted to log in.
+
 **Note**: This feature requires at least 1GB of memory and is not supported on certain SKUs, including `Standard_B1ls`, `Basic_A0`, and `Standard_A0`.
+
+**Note**: When specifying `principal_ids`, this module will create Azure role assignments for those principals. The user deploying this module must have sufficient permissions to create role assignments (typically the `Owner` role or a custom role with the necessary permissions).
 
 Type:
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ The following resources are used by this module:
 - [azurerm_network_interface.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface) (resource)
 - [azurerm_public_ip.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) (resource)
 - [azurerm_role_assignment.entra_id_login](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
+- [azurerm_role_assignment.entra_id_login_user](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
 - [azurerm_user_assigned_identity.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) (resource)
 - [azurerm_virtual_machine_data_disk_attachment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_data_disk_attachment) (resource)
 - [azurerm_virtual_machine_extension.domain_join](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_extension) (resource)
@@ -501,18 +502,22 @@ Default: `true`
 
 ### <a name="input_entra_id_login"></a> [entra\_id\_login](#input\_entra\_id\_login)
 
-Description: Configures Entra ID-based login for virtual machines. Set `enabled` to `true` to activate this feature and specify the list of `principal_ids` permitted to log in.
+Description: Configures Entra ID-based login for virtual machines. Set `enabled` to `true` to activate this feature and specify the lists of `admin_login_principal_ids` and `user_login_principal_ids` that are permitted to log in.
 
 **Note**: This feature requires at least 1GB of memory and is not supported on certain SKUs, including `Standard_B1ls`, `Basic_A0`, and `Standard_A0`.
 
-**Note**: When specifying `principal_ids`, this module will create Azure role assignments for those principals. The user deploying this module must have sufficient permissions to create role assignments (typically the `Owner` role or a custom role with the necessary permissions).
+**Note**: When specifying `admin_login_principal_ids` or `user_login_principal_ids`, this module will create Azure role assignments for those principals. The user deploying this module must have sufficient permissions to create role assignments (typically the `Owner` role or a custom role with the necessary permissions).
+
+**Deprecation Notice**: The `principal_ids` argument is deprecated and will be removed in version 2.0 of this module. Please use `admin_login_principal_ids` and `user_login_principal_ids` instead.
 
 Type:
 
 ```hcl
 object({
-    enabled       = optional(bool)
-    principal_ids = optional(list(string), [])
+    enabled                   = optional(bool)
+    principal_ids             = optional(list(string), []) # !! DEPRECATED !!
+    admin_login_principal_ids = optional(list(string), [])
+    user_login_principal_ids  = optional(list(string), [])
   })
 ```
 

--- a/r-extensions.tf
+++ b/r-extensions.tf
@@ -82,6 +82,29 @@ resource "azurerm_virtual_machine_extension" "entra_id_login" {
   }
 }
 
+resource "azurerm_role_assignment" "entra_id_login_admin" {
+  for_each = (
+    var.entra_id_login.enabled
+    ? toset(concat(var.entra_id_login.principal_ids, var.entra_id_login.admin_login_principal_ids))
+    : []
+  )
+
+  principal_id         = each.value
+  role_definition_name = "Virtual Machine Administrator Login"
+  scope                = local.virtual_machine.id
+}
+
+resource "azurerm_role_assignment" "entra_id_login_user" {
+  for_each = (
+    var.entra_id_login.enabled ? toset(var.entra_id_login.user_login_principal_ids) : []
+  )
+
+  principal_id         = each.value
+  role_definition_name = "Virtual Machine User Login"
+  scope                = local.virtual_machine.id
+}
+
+
 resource "azurerm_virtual_machine_extension" "domain_join" {
   count = var.domain_join.enabled ? 1 : 0
 

--- a/r-identity.tf
+++ b/r-identity.tf
@@ -15,9 +15,23 @@ resource "azurerm_user_assigned_identity" "this" {
 }
 
 resource "azurerm_role_assignment" "entra_id_login" {
-  for_each = var.entra_id_login.enabled ? toset(var.entra_id_login.principal_ids) : []
+  for_each = (
+    var.entra_id_login.enabled
+    ? toset(concat(var.entra_id_login.principal_ids, var.entra_id_login.admin_login_principal_ids))
+    : []
+  )
 
   principal_id         = each.value
   role_definition_name = "Virtual Machine Administrator Login"
+  scope                = local.virtual_machine.id
+}
+
+resource "azurerm_role_assignment" "entra_id_login_user" {
+  for_each = (
+    var.entra_id_login.enabled ? toset(var.entra_id_login.user_login_principal_ids) : []
+  )
+
+  principal_id         = each.value
+  role_definition_name = "Virtual Machine User Login"
   scope                = local.virtual_machine.id
 }

--- a/r-identity.tf
+++ b/r-identity.tf
@@ -18,25 +18,3 @@ moved {
   from = azurerm_role_assignment.entra_id_login
   to   = azurerm_role_assignment.entra_id_login_admin
 }
-
-resource "azurerm_role_assignment" "entra_id_login_admin" {
-  for_each = (
-    var.entra_id_login.enabled
-    ? toset(concat(var.entra_id_login.principal_ids, var.entra_id_login.admin_login_principal_ids))
-    : []
-  )
-
-  principal_id         = each.value
-  role_definition_name = "Virtual Machine Administrator Login"
-  scope                = local.virtual_machine.id
-}
-
-resource "azurerm_role_assignment" "entra_id_login_user" {
-  for_each = (
-    var.entra_id_login.enabled ? toset(var.entra_id_login.user_login_principal_ids) : []
-  )
-
-  principal_id         = each.value
-  role_definition_name = "Virtual Machine User Login"
-  scope                = local.virtual_machine.id
-}

--- a/r-identity.tf
+++ b/r-identity.tf
@@ -14,7 +14,12 @@ resource "azurerm_user_assigned_identity" "this" {
   tags                = var.tags
 }
 
-resource "azurerm_role_assignment" "entra_id_login" {
+moved {
+  from = azurerm_role_assignment.entra_id_login
+  to   = azurerm_role_assignment.entra_id_login_admin
+}
+
+resource "azurerm_role_assignment" "entra_id_login_admin" {
   for_each = (
     var.entra_id_login.enabled
     ? toset(concat(var.entra_id_login.principal_ids, var.entra_id_login.admin_login_principal_ids))

--- a/tests/local/input_entra_id.tftest.hcl
+++ b/tests/local/input_entra_id.tftest.hcl
@@ -21,11 +21,6 @@ run "entra_id_extension_and_identity_type_should_be_created" {
   }
 
   assert {
-    condition     = length(azurerm_role_assignment.entra_id_login) != 0
-    error_message = "It is not possible to install the AAD-Extension without a given 'principal_id'."
-  }
-
-  assert {
     condition     = local.identity_type == "SystemAssigned"
     error_message = "It is not possible to install the EntraID-Extension without setting the Idenity to 'SystemAssigned' OR 'SystemAssigned, UserAssigned'."
   }
@@ -52,11 +47,6 @@ run "entra_id_extension_and_add_identity_type_should_be_created" {
   }
 
   assert {
-    condition     = length(azurerm_role_assignment.entra_id_login) != 0
-    error_message = "It is not possible to install the AAD-Extension without a given 'principal_id'."
-  }
-
-  assert {
     condition     = local.identity_type == "SystemAssigned, UserAssigned"
     error_message = "It is not possible to install the EntraID-Extension without setting the Idenity to 'SystemAssigned' OR 'SystemAssigned, UserAssigned'."
   }
@@ -71,7 +61,12 @@ run "nothing_should_be_created_regarding_entra_id_login" {
   }
 
   assert {
-    condition     = length(azurerm_role_assignment.entra_id_login) == 0
+    condition     = length(azurerm_role_assignment.entra_id_login_admin) == 0
+    error_message = "No role_assignment for EntraID should be created when 'entra_id_login' is disabled."
+  }
+
+  assert {
+    condition     = length(azurerm_role_assignment.entra_id_login_user) == 0
     error_message = "No role_assignment for EntraID should be created when 'entra_id_login' is disabled."
   }
 

--- a/tests/remote/main.tf
+++ b/tests/remote/main.tf
@@ -78,8 +78,8 @@ module "tftest_02" {
 
   entra_id_login = {
     enabled                   = true
-    principal_ids             = ["c7d07362-db52-416c-a17c-4b152781b9cc"]
-    admin_login_principal_ids = ["c7d07362-db52-416c-a17c-4b152781b9cc"]
-    user_login_principal_ids  = ["c7d07362-db52-416c-a17c-4b152781b9cc"]
+    principal_ids             = ["52c45cde-8aa6-45a7-b717-686d20a2fbbf"]
+    admin_login_principal_ids = ["52c45cde-8aa6-45a7-b717-686d20a2fbbf"]
+    user_login_principal_ids  = ["52c45cde-8aa6-45a7-b717-686d20a2fbbf"]
   }
 }

--- a/tests/remote/main.tf
+++ b/tests/remote/main.tf
@@ -75,4 +75,11 @@ module "tftest_02" {
   image               = "Ubuntu2204"
   key_vault_id        = local.key_vault_id
   subnet_id           = local.subnet_id
+
+  entra_id_login = {
+    enabled                   = true
+    principal_ids             = ["c7d07362-db52-416c-a17c-4b152781b9cc"]
+    admin_login_principal_ids = ["c7d07362-db52-416c-a17c-4b152781b9cc"]
+    user_login_principal_ids  = ["c7d07362-db52-416c-a17c-4b152781b9cc"]
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -310,16 +310,20 @@ variable "encryption_at_host_enabled" {
 
 variable "entra_id_login" {
   description = <<-EOD
-    Configures Entra ID-based login for virtual machines. Set `enabled` to `true` to activate this feature and specify the list of `principal_ids` permitted to log in.
+    Configures Entra ID-based login for virtual machines. Set `enabled` to `true` to activate this feature and specify the lists of `admin_login_principal_ids` and `user_login_principal_ids` that are permitted to log in.
 
     **Note**: This feature requires at least 1GB of memory and is not supported on certain SKUs, including `Standard_B1ls`, `Basic_A0`, and `Standard_A0`.
 
-    **Note**: When specifying `principal_ids`, this module will create Azure role assignments for those principals. The user deploying this module must have sufficient permissions to create role assignments (typically the `Owner` role or a custom role with the necessary permissions).
+    **Note**: When specifying `admin_login_principal_ids` or `user_login_principal_ids`, this module will create Azure role assignments for those principals. The user deploying this module must have sufficient permissions to create role assignments (typically the `Owner` role or a custom role with the necessary permissions).
+
+    **Deprecation Notice**: The `principal_ids` argument is deprecated and will be removed in version 2.0 of this module. Please use `admin_login_principal_ids` and `user_login_principal_ids` instead.
   EOD
 
   type = object({
-    enabled       = optional(bool)
-    principal_ids = optional(list(string), [])
+    enabled                   = optional(bool)
+    principal_ids             = optional(list(string), []) # !! DEPRECATED !!
+    admin_login_principal_ids = optional(list(string), [])
+    user_login_principal_ids  = optional(list(string), [])
   })
 
   default = ({

--- a/variables.tf
+++ b/variables.tf
@@ -310,13 +310,18 @@ variable "encryption_at_host_enabled" {
 
 variable "entra_id_login" {
   description = <<-EOD
-      Configures Entra ID-based login for virtual machines. Set `enabled` to `true` to activate this feature and define the list of `principal_ids` permitted to log in.
+    Configures Entra ID-based login for virtual machines. Set `enabled` to `true` to activate this feature and specify the list of `principal_ids` permitted to log in.
+
     **Note**: This feature requires at least 1GB of memory and is not supported on certain SKUs, including `Standard_B1ls`, `Basic_A0`, and `Standard_A0`.
+
+    **Note**: When specifying `principal_ids`, this module will create Azure role assignments for those principals. The user deploying this module must have sufficient permissions to create role assignments (typically the `Owner` role or a custom role with the necessary permissions).
   EOD
+
   type = object({
     enabled       = optional(bool)
     principal_ids = optional(list(string), [])
   })
+
   default = ({
     enabled = false
   })


### PR DESCRIPTION
Update the Entra ID login configuration to support separate admin and user principal IDs, add necessary permissions notes for role assignments, and deprecate the `principal_ids` argument.