### PR TITLE
Require valid principal ID for Entra ID login validation

### DIFF
--- a/tests/local/input_entra_id.tftest.hcl
+++ b/tests/local/input_entra_id.tftest.hcl
@@ -9,8 +9,8 @@ run "entra_id_extension_and_identity_type_should_be_created" {
   variables {
     extensions = []
     entra_id_login = {
-      enabled       = true
-      principal_ids = ["00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000001"]
+      enabled                   = true
+      admin_login_principal_ids = ["00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000001"]
     }
 
   }
@@ -35,8 +35,8 @@ run "entra_id_extension_and_add_identity_type_should_be_created" {
     identity = {
     type = "UserAssigned" }
     entra_id_login = {
-      enabled       = true
-      principal_ids = ["00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000001"]
+      enabled                   = true
+      admin_login_principal_ids = ["00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000001"]
     }
 
   }
@@ -85,8 +85,8 @@ run "entra_id_extension_and_identity_type_is_given" {
     identity = {
     type = "SystemAssigned, UserAssigned" }
     entra_id_login = {
-      enabled       = true
-      principal_ids = ["00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000001"]
+      enabled                   = true
+      admin_login_principal_ids = ["00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000001"]
     }
 
   }

--- a/variables.tf
+++ b/variables.tf
@@ -338,8 +338,13 @@ variable "entra_id_login" {
   }
 
   validation {
-    condition     = !var.entra_id_login.enabled ? true : length(var.entra_id_login.principal_ids) > 0
-    error_message = "When 'entra_id_login.enabled' is 'true', 'principal_ids' must contain at least one valid principal ID."
+    condition = anytrue([
+      !var.entra_id_login.enabled,
+      length(var.entra_id_login.principal_ids) > 0,
+      length(var.entra_id_login.admin_login_principal_ids) > 0,
+      length(var.entra_id_login.user_login_principal_ids) > 0
+    ])
+    error_message = "When 'entra_id_login.enabled' is 'true', 'admin_login_principal_ids' or 'user_login_principal_ids' must contain at least one valid principal ID."
   }
 
 }


### PR DESCRIPTION
Update the Entra ID login validation to require at least one valid principal ID in either the `admin_login_principal_ids` or `user_login_principal_ids` when enabled. Adjusted related variables and error messages accordingly.