### PR TITLE
Add `dns_servers` variable for network configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,14 @@ list(object({
 
 Default: `[]`
 
+### <a name="input_dns_servers"></a> [dns\_servers](#input\_dns\_servers)
+
+Description: A list of DNS server IP addresses to assign to the primary network interface of the virtual machine. These servers will override the default DNS settings provided by the subnet or virtual network.
+
+Type: `list(string)`
+
+Default: `[]`
+
 ### <a name="input_domain_join"></a> [domain\_join](#input\_domain\_join)
 
 Description: Enable domain join for the virtual machine. This feature is not supported on Linux Virtual Machines.

--- a/r-network.tf
+++ b/r-network.tf
@@ -15,6 +15,8 @@ resource "azurerm_network_interface" "this" {
   resource_group_name = var.resource_group_name
   tags                = var.tags
 
+  dns_servers = var.dns_servers
+
   ip_configuration {
     name                          = "ipconfig1"
     private_ip_address            = var.private_ip_address

--- a/variables.tf
+++ b/variables.tf
@@ -1,10 +1,4 @@
 locals {
-  windows_license_types = ["None", "Windows_Client", "Windows_Server"]
-  linux_license_types = [
-    "RHEL_BYOS", "RHEL_BASE", "RHEL_EUS", "RHEL_SAPAPPS", "RHEL_SAPHA", "RHEL_BASESAPAPPS", "RHEL_BASESAPHA",
-    "SLES_BYOS", "SLES_SAP", "SLES_HPC"
-  ]
-
   identity_type = (
     var.entra_id_login.enabled ? (
       strcontains(try(var.identity.type, ""), "UserAssigned") ?
@@ -12,6 +6,11 @@ locals {
       "SystemAssigned"
     ) :
   try(var.identity.type, null))
+  linux_license_types = [
+    "RHEL_BYOS", "RHEL_BASE", "RHEL_EUS", "RHEL_SAPAPPS", "RHEL_SAPHA", "RHEL_BASESAPAPPS", "RHEL_BASESAPHA",
+    "SLES_BYOS", "SLES_SAP", "SLES_HPC"
+  ]
+  windows_license_types = ["None", "Windows_Client", "Windows_Server"]
 }
 
 variable "additional_capabilities" {
@@ -234,6 +233,13 @@ variable "data_disks" {
     storage_account_type = optional(string, "Premium_LRS")
   }))
 
+  default = []
+}
+
+variable "dns_servers" {
+  description = "A list of DNS server IP addresses to assign to the primary network interface of the virtual machine. These servers will override the default DNS settings provided by the subnet or virtual network."
+
+  type    = list(string)
   default = []
 }
 


### PR DESCRIPTION
Introduce a new variable to specify DNS server IP addresses for the primary network interface of the virtual machine, allowing customization of DNS settings.