### PR TITLE
Remove unecessary `entra_id_login` variable validation

### DIFF
--- a/tests/local/input_entra_id.tftest.hcl
+++ b/tests/local/input_entra_id.tftest.hcl
@@ -8,11 +8,11 @@ run "entra_id_extension_and_identity_type_should_be_created" {
 
   variables {
     extensions = []
+
     entra_id_login = {
       enabled                   = true
       admin_login_principal_ids = ["00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000001"]
     }
-
   }
 
   assert {
@@ -24,7 +24,6 @@ run "entra_id_extension_and_identity_type_should_be_created" {
     condition     = local.identity_type == "SystemAssigned"
     error_message = "It is not possible to install the EntraID-Extension without setting the Idenity to 'SystemAssigned' OR 'SystemAssigned, UserAssigned'."
   }
-
 }
 
 run "entra_id_extension_and_add_identity_type_should_be_created" {
@@ -32,13 +31,15 @@ run "entra_id_extension_and_add_identity_type_should_be_created" {
 
   variables {
     extensions = []
+
     identity = {
-    type = "UserAssigned" }
+      type = "UserAssigned"
+    }
+
     entra_id_login = {
       enabled                   = true
       admin_login_principal_ids = ["00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000001"]
     }
-
   }
 
   assert {
@@ -50,7 +51,6 @@ run "entra_id_extension_and_add_identity_type_should_be_created" {
     condition     = local.identity_type == "SystemAssigned, UserAssigned"
     error_message = "It is not possible to install the EntraID-Extension without setting the Idenity to 'SystemAssigned' OR 'SystemAssigned, UserAssigned'."
   }
-
 }
 
 run "nothing_should_be_created_regarding_entra_id_login" {
@@ -74,7 +74,6 @@ run "nothing_should_be_created_regarding_entra_id_login" {
     condition     = local.identity_type == var.identity
     error_message = "No identity type should be created when 'entra_id_login' is disabled."
   }
-
 }
 
 run "entra_id_extension_and_identity_type_is_given" {
@@ -82,18 +81,19 @@ run "entra_id_extension_and_identity_type_is_given" {
 
   variables {
     extensions = []
+
     identity = {
-    type = "SystemAssigned, UserAssigned" }
+      type = "SystemAssigned, UserAssigned"
+    }
+
     entra_id_login = {
       enabled                   = true
       admin_login_principal_ids = ["00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000001"]
     }
-
   }
 
   assert {
     condition     = local.identity_type == "SystemAssigned, UserAssigned"
     error_message = "Keep 'SystemAssigned, UserAssigned' in case of usage."
   }
-
 }

--- a/tests/local/input_entra_id.tftest.hcl
+++ b/tests/local/input_entra_id.tftest.hcl
@@ -22,7 +22,7 @@ run "entra_id_extension_and_identity_type_should_be_created" {
 
   assert {
     condition     = local.identity_type == "SystemAssigned"
-    error_message = "It is not possible to install the EntraID-Extension without setting the Idenity to 'SystemAssigned' OR 'SystemAssigned, UserAssigned'."
+    error_message = "It is not possible to install the EntraID-Extension without setting the Identity to 'SystemAssigned' OR 'SystemAssigned, UserAssigned'."
   }
 }
 
@@ -49,7 +49,7 @@ run "entra_id_extension_and_add_identity_type_should_be_created" {
 
   assert {
     condition     = local.identity_type == "SystemAssigned, UserAssigned"
-    error_message = "It is not possible to install the EntraID-Extension without setting the Idenity to 'SystemAssigned' OR 'SystemAssigned, UserAssigned'."
+    error_message = "It is not possible to install the EntraID-Extension without setting the Identity to 'SystemAssigned' OR 'SystemAssigned, UserAssigned'."
   }
 }
 

--- a/tests/local/input_entra_id.tftest.hcl
+++ b/tests/local/input_entra_id.tftest.hcl
@@ -97,3 +97,30 @@ run "entra_id_extension_and_identity_type_is_given" {
     error_message = "Keep 'SystemAssigned, UserAssigned' in case of usage."
   }
 }
+
+run "entra_id_extension_created_without_principal_ids_and_no_role_assignments" {
+  command = plan
+
+  variables {
+    extensions = []
+
+    entra_id_login = {
+      enabled = true
+    }
+  }
+
+  assert {
+    condition     = length(azurerm_virtual_machine_extension.entra_id_login) == 1
+    error_message = "The EntraID extension should be created even if no principal IDs are provided."
+  }
+
+  assert {
+    condition     = length(azurerm_role_assignment.entra_id_login_user) == 0
+    error_message = "No user role assignments should be created when no principal IDs are provided for EntraID login."
+  }
+
+  assert {
+    condition     = length(azurerm_role_assignment.entra_id_login_admin) == 0
+    error_message = "No admin role assignments should be created when no principal IDs are provided for EntraID login."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -342,17 +342,6 @@ variable "entra_id_login" {
     !contains(["Standard_B1ls", "Basic_A0", "Standard_A0"], var.size))
     error_message = "Entra ID Extension requires at least 1GB of memory; set var.size to an SKU that meets this requirement."
   }
-
-  validation {
-    condition = anytrue([
-      !var.entra_id_login.enabled,
-      length(var.entra_id_login.principal_ids) > 0,
-      length(var.entra_id_login.admin_login_principal_ids) > 0,
-      length(var.entra_id_login.user_login_principal_ids) > 0
-    ])
-    error_message = "When 'entra_id_login.enabled' is 'true', 'admin_login_principal_ids' or 'user_login_principal_ids' must contain at least one valid principal ID."
-  }
-
 }
 
 variable "extensions" {


### PR DESCRIPTION
## Description

This PR addresses #84 by removing the unnecessary variable validation that restricted Entra ID extension installation when no principal_id was defined via input variable.

## PR Checklist
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added documentation written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have checked for a proper tag for this PR: `breaking-change`, `feature`, `fix`, `other`, `ignore-release`
- [x] I have used a **meaningful** PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previously, the extension could not be installed unless a principal_id was explicitly provided. This restriction was technically unnecessary and limited flexibility. With this change, the extension can now be used without requiring a user or admin to be specified.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
