### PR TITLE
Allow tags for each data_disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ Parameter | Description
 `name` | Specifies the name of the Managed Disk. If omitted a name will be generated based on `name`.
 `source_resource_id` | The ID of an existing Managed Disk or Snapshot to copy when `create_option` is `Cop`y or the recovery point to restore when `create_option` is `Restore`.
 `storage_account_type` | The type of storage to use for the managed disk. Possible values are `Standard_LRS`, `StandardSSD_ZRS`, `Premium_LRS`, `PremiumV2_LRS`, `Premium_ZRS`, `StandardSSD_LRS` or `UltraSSD_LRS`.
+`tags` | Tags specific to this data disk.
 
 Type:
 
@@ -416,6 +417,7 @@ list(object({
     name                 = optional(string)
     source_resource_id   = optional(string)
     storage_account_type = optional(string, "Premium_LRS")
+    tags                 = optional(map(string), {})
   }))
 ```
 

--- a/r-disk.tf
+++ b/r-disk.tf
@@ -18,7 +18,7 @@ resource "azurerm_managed_disk" "this" {
   name                = each.value.name
   location            = var.location
   resource_group_name = var.resource_group_name
-  tags                = var.tags
+  tags                = merge(var.tags, each.value.tags)
 
   create_option        = each.value.create_option
   disk_size_gb         = each.value.disk_size_gb

--- a/variables.tf
+++ b/variables.tf
@@ -221,6 +221,7 @@ variable "data_disks" {
     `name` | Specifies the name of the Managed Disk. If omitted a name will be generated based on `name`.
     `source_resource_id` | The ID of an existing Managed Disk or Snapshot to copy when `create_option` is `Cop`y or the recovery point to restore when `create_option` is `Restore`.
     `storage_account_type` | The type of storage to use for the managed disk. Possible values are `Standard_LRS`, `StandardSSD_ZRS`, `Premium_LRS`, `PremiumV2_LRS`, `Premium_ZRS`, `StandardSSD_LRS` or `UltraSSD_LRS`.
+    `tags` | Tags specific to this data disk.
   EOT
 
   type = list(object({
@@ -231,6 +232,7 @@ variable "data_disks" {
     name                 = optional(string)
     source_resource_id   = optional(string)
     storage_account_type = optional(string, "Premium_LRS")
+    tags                 = optional(map(string), {})
   }))
 
   default = []


### PR DESCRIPTION
## Summary

Add support for **per–data disk tagging** by extending the `data_disks` schema with an optional `tags` map and merging those tags with the module-level `var.tags` when creating `azurerm_managed_disk` resources.

## What Changed

- Extended `data_disks` object type to include an optional `tags` map (default `{}`).
- Updated documentation in `README.md` and `variables.tf`.
- Updated disk resource tagging logic to merge global and per-disk tags.

## Why

Consumers may require disk-specific metadata (e.g., cost center, classification, backup policy) while maintaining a consistent baseline tag set across the module. This change enables flexible tagging without duplicating resources or modifying module structure.

## Impact

- **Backwards compatible**: existing configurations continue to work unchanged.
- **New capability**: per-disk tags via `data_disks[*].tags`.
- **Precedence rule**: per-disk tags override `var.tags` on key conflicts.
- **Edge case**: if `var.tags` is ever set to `null`, `merge()` would fail (assuming `var.tags` is expected to be a map).