### PR TITLE
feat: add support for conditional creation and association of network security groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,14 @@ Type: `bool`
 
 Default: `true`
 
+### <a name="input_create_network_security_group"></a> [create\_network\_security\_group](#input\_create\_network\_security\_group)
+
+Description: Create (`true`) and associate a default Network Security Group for the module-created network interface when `network_security_group_id` is omitted. If disabled (`false`) and `network_security_group_id` is omitted, no Network Security Group is associated with the module-created network interface.
+
+Type: `bool`
+
+Default: `true`
+
 ### <a name="input_create_public_ip_address"></a> [create\_public\_ip\_address](#input\_create\_public\_ip\_address)
 
 Description: If set to `true` a Azure public IP address will be created and assigned to the default network interface.
@@ -667,7 +675,7 @@ Default: `null`
 Description: The resource ID of an existing Azure Network Security Group to associate with the network interface created by this module.
 
 - Applies only when `create_network_interface` is `true`.
-- If omitted and `create_network_interface` is `true`, this module creates and associates a default Network Security Group.
+- If omitted and both `create_network_interface` and `create_network_security_group` are `true`, this module creates and associates a default Network Security Group.
 
 Type: `string`
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ The following resources are used by this module:
 - [azurerm_managed_disk.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/managed_disk) (resource)
 - [azurerm_network_interface.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface) (resource)
 - [azurerm_network_interface_security_group_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface_security_group_association) (resource)
-- [azurerm_network_security_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_group) (resource)
 - [azurerm_public_ip.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) (resource)
 - [azurerm_role_assignment.entra_id_login_admin](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
 - [azurerm_role_assignment.entra_id_login_user](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
@@ -375,14 +374,6 @@ Default: `null`
 ### <a name="input_create_network_interface"></a> [create\_network\_interface](#input\_create\_network\_interface)
 
 Description: Create (`true`) a network interface for the virtual machine. If disabled (`false`), the `subnet_id` must be omitted and `network_interface_ids` must be defined.
-
-Type: `bool`
-
-Default: `true`
-
-### <a name="input_create_network_security_group"></a> [create\_network\_security\_group](#input\_create\_network\_security\_group)
-
-Description: Create (`true`) and associate a default Network Security Group for the module-created network interface when `network_security_group_id` is omitted. If disabled (`false`) and `network_security_group_id` is omitted, no Network Security Group is associated with the module-created network interface.
 
 Type: `bool`
 
@@ -675,7 +666,7 @@ Default: `null`
 Description: The resource ID of an existing Azure Network Security Group to associate with the network interface created by this module.
 
 - Applies only when `create_network_interface` is `true`.
-- If omitted and both `create_network_interface` and `create_network_security_group` are `true`, this module creates and associates a default Network Security Group.
+- If omitted, no Network Security Group is associated with the module-created network interface.
 
 Type: `string`
 

--- a/r-network.tf
+++ b/r-network.tf
@@ -13,7 +13,7 @@ locals {
 
 resource "azurerm_network_security_group" "this" {
 
-  count = var.create_network_interface && var.network_security_group_id == null ? 1 : 0
+  count = var.create_network_interface && var.create_network_security_group && var.network_security_group_id == null ? 1 : 0
 
   name                = "nsg-${trimprefix(var.name, "vm-")}"
   location            = var.location
@@ -45,7 +45,7 @@ resource "azurerm_network_interface" "this" {
 }
 
 resource "azurerm_network_interface_security_group_association" "this" {
-  count = var.create_network_interface ? 1 : 0
+  count = var.create_network_interface && (var.create_network_security_group || var.network_security_group_id != null) ? 1 : 0
 
   network_interface_id      = azurerm_network_interface.this[0].id
   network_security_group_id = local.network_security_group_id

--- a/r-network.tf
+++ b/r-network.tf
@@ -3,22 +3,8 @@ locals {
     azurerm_network_interface.this[*].id,
     (var.network_interface_ids != null ? var.network_interface_ids : [])
   )
-  network_security_group_id = (
-    var.network_security_group_id != null ?
-    var.network_security_group_id :
-    try(one(azurerm_network_security_group.this[*].id), null)
-  )
+  network_security_group_id = var.network_security_group_id
 
-}
-
-resource "azurerm_network_security_group" "this" {
-
-  count = var.create_network_interface && var.create_network_security_group && var.network_security_group_id == null ? 1 : 0
-
-  name                = "nsg-${trimprefix(var.name, "vm-")}"
-  location            = var.location
-  resource_group_name = var.resource_group_name
-  tags                = var.tags
 }
 
 resource "azurerm_network_interface" "this" {
@@ -45,7 +31,7 @@ resource "azurerm_network_interface" "this" {
 }
 
 resource "azurerm_network_interface_security_group_association" "this" {
-  count = var.create_network_interface && (var.create_network_security_group || var.network_security_group_id != null) ? 1 : 0
+  count = var.create_network_interface && var.network_security_group_id != null ? 1 : 0
 
   network_interface_id      = azurerm_network_interface.this[0].id
   network_security_group_id = local.network_security_group_id

--- a/tests/local/input_network.tftest.hcl
+++ b/tests/local/input_network.tftest.hcl
@@ -21,13 +21,8 @@ run "should_use_subnet_id" {
   }
 
   assert {
-    condition     = length(azurerm_network_security_group.this) == 1
-    error_message = "Expected the module to create a default network security group when no network_security_group_id is provided."
-  }
-
-  assert {
-    condition     = length(azurerm_network_interface_security_group_association.this) == 1
-    error_message = "Expected the created network interface to have a network security group association."
+    condition     = length(azurerm_network_interface_security_group_association.this) == 0
+    error_message = "Expected no network security group association when network_security_group_id is not provided."
   }
 }
 
@@ -71,52 +66,35 @@ run "should_use_existing_network_security_group_for_created_network_interface" {
   }
 
   assert {
-    condition     = length(azurerm_network_security_group.this) == 0
-    error_message = "Expected no network security group to be created when network_security_group_id is provided."
-  }
-
-  assert {
     condition     = length(azurerm_network_interface_security_group_association.this) == 1
     error_message = "Expected the created network interface to have a network security group association when network_security_group_id is provided."
   }
 }
 
-run "should_not_create_or_associate_network_security_group_when_disabled" {
+run "should_not_associate_network_security_group_when_not_provided" {
   command = plan
 
   variables {
-    create_network_security_group = false
-    subnet_id                     = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/snet"
-  }
-
-  assert {
-    condition     = length(azurerm_network_security_group.this) == 0
-    error_message = "Expected no network security group to be created when create_network_security_group is disabled."
+    subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/snet"
   }
 
   assert {
     condition     = length(azurerm_network_interface_security_group_association.this) == 0
-    error_message = "Expected no network security group association when create_network_security_group is disabled and no network_security_group_id is provided."
+    error_message = "Expected no network security group association when no network_security_group_id is provided."
   }
 }
 
-run "should_associate_existing_network_security_group_when_default_creation_disabled" {
+run "should_associate_existing_network_security_group_when_provided" {
   command = plan
 
   variables {
-    create_network_security_group = false
-    network_security_group_id     = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/networkSecurityGroups/nsg-existing"
-    subnet_id                     = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/snet"
-  }
-
-  assert {
-    condition     = length(azurerm_network_security_group.this) == 0
-    error_message = "Expected no network security group to be created when create_network_security_group is disabled."
+    network_security_group_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/networkSecurityGroups/nsg-existing"
+    subnet_id                 = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/snet"
   }
 
   assert {
     condition     = length(azurerm_network_interface_security_group_association.this) == 1
-    error_message = "Expected the provided network_security_group_id to still be associated when default network security group creation is disabled."
+    error_message = "Expected the provided network_security_group_id to be associated with the created network interface."
   }
 }
 

--- a/tests/local/input_network.tftest.hcl
+++ b/tests/local/input_network.tftest.hcl
@@ -81,6 +81,45 @@ run "should_use_existing_network_security_group_for_created_network_interface" {
   }
 }
 
+run "should_not_create_or_associate_network_security_group_when_disabled" {
+  command = plan
+
+  variables {
+    create_network_security_group = false
+    subnet_id                     = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/snet"
+  }
+
+  assert {
+    condition     = length(azurerm_network_security_group.this) == 0
+    error_message = "Expected no network security group to be created when create_network_security_group is disabled."
+  }
+
+  assert {
+    condition     = length(azurerm_network_interface_security_group_association.this) == 0
+    error_message = "Expected no network security group association when create_network_security_group is disabled and no network_security_group_id is provided."
+  }
+}
+
+run "should_associate_existing_network_security_group_when_default_creation_disabled" {
+  command = plan
+
+  variables {
+    create_network_security_group = false
+    network_security_group_id     = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/networkSecurityGroups/nsg-existing"
+    subnet_id                     = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/snet"
+  }
+
+  assert {
+    condition     = length(azurerm_network_security_group.this) == 0
+    error_message = "Expected no network security group to be created when create_network_security_group is disabled."
+  }
+
+  assert {
+    condition     = length(azurerm_network_interface_security_group_association.this) == 1
+    error_message = "Expected the provided network_security_group_id to still be associated when default network security group creation is disabled."
+  }
+}
+
 
 run "should_assert_three_network_interfaces" {
   command = plan

--- a/variables.tf
+++ b/variables.tf
@@ -194,12 +194,6 @@ variable "create_network_interface" {
   default     = true
 }
 
-variable "create_network_security_group" {
-  description = "Create (`true`) and associate a default Network Security Group for the module-created network interface when `network_security_group_id` is omitted. If disabled (`false`) and `network_security_group_id` is omitted, no Network Security Group is associated with the module-created network interface."
-  type        = bool
-  default     = true
-}
-
 variable "create_public_ip_address" {
   description = "If set to `true` a Azure public IP address will be created and assigned to the default network interface."
   default     = false
@@ -550,7 +544,7 @@ variable "network_security_group_id" {
   The resource ID of an existing Azure Network Security Group to associate with the network interface created by this module.
 
   - Applies only when `create_network_interface` is `true`.
-  - If omitted and both `create_network_interface` and `create_network_security_group` are `true`, this module creates and associates a default Network Security Group.
+  - If omitted, no Network Security Group is associated with the module-created network interface.
   EOT
 
   default = null

--- a/variables.tf
+++ b/variables.tf
@@ -194,6 +194,12 @@ variable "create_network_interface" {
   default     = true
 }
 
+variable "create_network_security_group" {
+  description = "Create (`true`) and associate a default Network Security Group for the module-created network interface when `network_security_group_id` is omitted. If disabled (`false`) and `network_security_group_id` is omitted, no Network Security Group is associated with the module-created network interface."
+  type        = bool
+  default     = true
+}
+
 variable "create_public_ip_address" {
   description = "If set to `true` a Azure public IP address will be created and assigned to the default network interface."
   default     = false
@@ -544,7 +550,7 @@ variable "network_security_group_id" {
   The resource ID of an existing Azure Network Security Group to associate with the network interface created by this module.
 
   - Applies only when `create_network_interface` is `true`.
-  - If omitted and `create_network_interface` is `true`, this module creates and associates a default Network Security Group.
+  - If omitted and both `create_network_interface` and `create_network_security_group` are `true`, this module creates and associates a default Network Security Group.
   EOT
 
   default = null


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## PR Checklist
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added documentation written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have checked for a proper tag for this PR: `breaking-change`, `feature`, `fix`, `other`, `ignore-release`
- [x] I have used a **meaningful** PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Feedback from @matthiasbretag:

But we have a new issue. For some reason, network security groups are created now for each NIC which is not a behavior we want or require. Would you please check and make another change so this gets fixed. I believe this behavior might have been introduced with one of the prior versions, probably v1.8.0.
 
With the adjustments below one should set the following parameter;
 
```
create_network_security_group  = false
```
 
and this should prevent the creation of NSGs.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
